### PR TITLE
Revert "Bump pyrate-limiter from 2.10.0 to 3.0.1 (#134)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ psycopg2-binary==2.9.7
 pydictionary==2.0.1
 pykeyboard==0.1.5
 pynewtonmath==1.0.1
-pyrate-limiter==3.0.1
+pyrate-limiter==2.10.0
 pyrogram==2.0.106
 python-telegram-bot==13.15
 regex==2023.8.8


### PR DESCRIPTION
This reverts commit d30ac8e0af056176211d1deb9a03e6bf8fc95a4d.